### PR TITLE
Fix color matching for Australasian / National rankins.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ sourceFiles=(
     "src/databases/database-core.js"
     "src/databases/database-abs.js"
     "src/databases/database-ft-50.js"
-    "src/databases/database-vhb.js",
+    "src/databases/database-vhb.js"
     # Engine
     "src/engine/ranking-engine.js"
     "src/engine/matching.js"

--- a/src/ui/ui-utils.js
+++ b/src/ui/ui-utils.js
@@ -58,7 +58,7 @@ var UIUtils = {
 				};
 
 				// National Rankings (use purple to distinguish from main tiers)
-				if (ranking.startsWith('Nat ')) {
+				if (ranking.startsWith('Nat') || ranking == "Au") {
 					return '#7B1FA2'; // Purple
 				};
 				break;


### PR DESCRIPTION
Updated `getRankingColor` to use a more accurate pattern for Nat rank. 
The function was looking for `Nat `, however most rankings started with `Nat:`
```bash
cat data.js | cut -d'"' -f4 | grep -E "Nat|Au"
```
saw ten `Nat/`, two `Nat(` and four `Nat`. With no matches to the `Nat ` from the code it should either be fixed here or on the data extraction side. Furthermore, added the base `Au` with no rank to the same purple color as Nat. As the base`Au` rank is the most common one. 

Also removed the comma from build.sh as it would not build for me with it.